### PR TITLE
feat: import `TypedQueryDocumentNode` type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This ESLint plugin is intended to be used in combination with
 [ts-graphql-plugin][] which generates TypeScript interfaces to match GraphQL
 queries in TypeScript code. This plugin provides an autofix that applies type
 assertions those GraphQL queries. With the type assertion queries can be passed
-to functions from, for example, Apollo Client, and result data types, and query
-variable types will propagate correctly.
+to functions from, for example, Apollo Client, and (with a little setup) result
+data types, and query variable types will propagate correctly.
 
 The plugin also makes checks to enforce some properties that are required for
 smooth operation:
@@ -20,7 +20,14 @@ This plugin is based on code from [@ts-gql/eslint-plugin][].
 [ts-graphql-plugin]: https://github.com/Quramy/ts-graphql-plugin
 [@ts-gql/eslint-plugin]: https://github.com/Thinkmill/ts-gql
 
-## Example usage
+## Prerequisites
+
+This plugin requires `graphql` v15.4.0 or later, and `ts-graphql-plugin` v2.1.0
+or later. `ts-graphql-plugin` must be configured to use its bundled
+`typed-query-document` add-on as documented
+[here](https://github.com/Quramy/ts-graphql-plugin#typed-query-document).
+
+## Setup
 
 Install:
 
@@ -43,13 +50,35 @@ module.exports = {
 };
 ```
 
+Configure `ts-graphql-plugin` to use the relevant add-on by setting up your
+`tsconfig.json` like this:
+
+```json
+{
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "ts-graphql-plugin",
+        "tag": "gql",
+        "schema": "schema.graphql",
+        "typegen": {
+          "addons": ["ts-graphql-plugin/addons/typed-query-document"]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Example usage
+
 Given a source file with content like this:
 
 ```ts
 import { gql } from "@apollo/client";
 
 export const getRecipesQuery = gql`
-  query getRecipes {
+  query GetRecipes {
     recipes {
       id
       title
@@ -65,17 +94,81 @@ Running ESLint with the `--fix` option will update the file to look like this:
 import { gql } from "@apollo/client";
 
 export const getRecipesQuery = gql`
-  query getRecipes {
+  query GetRecipes {
     recipes {
       id
       title
       description
     }
   }
-` as import("@graphql-typed-document-node/core").TypedDocumentNode<
-  import("./__generated__/get-recipes").getRecipes,
-  import("./__generated__/get-recipes").getRecipesVariables
->;
+` as import("./__generated__/get-recipes").GetRecipesDocument;
+```
+
+## Consuming the `TypedQueryDocumentNode` type
+
+The type that is applied to `gql` template expressions (for example
+`GetRecipesDocument` in the example above) is an alias for the
+[`TypedQueryDocumentNode`](https://github.com/graphql/graphql-js/blob/master/src/utilities/typedQueryDocumentNode.d.ts)
+type from `graphql-js` with type parameters for result data and variables filled
+in. This type was added to `graphql-js` very recently; so at the time of this
+writing there are no libraries that are set up to consume the type. But some
+libraries, such as Apollo Client, can consume a similar, third party type called
+`TypedDocumentNode`.
+
+You can make Apollo Client's functions (such as `useQuery`) process
+`TypedQueryDocumentNode` correctly by augmenting `TypedDocumentNode` so that
+`TypedQueryDocumentNode` is assignable to `TypedDocumentNode`. To do so include
+this typing file in your project:
+
+```ts
+// typed-document-node.d.ts
+
+import { DocumentNode } from "graphql";
+
+declare module "@graphql-typed-document-node/core" {
+  export interface TypedDocumentNode<
+    Result = {
+      [key: string]: any;
+    },
+    Variables = {
+      [key: string]: any;
+    }
+  > extends DocumentNode {
+    /**
+     * This type is used to ensure that the variables you pass in to the query
+     * are assignable to Variables and that the Result is assignable to whatever
+     * you pass your result to. The method is never actually implemented, but the
+     * type is valid because we list it as optional
+     */
+    __ensureTypesOfVariablesAndResultMatching?: (
+      variables: Variables
+    ) => Result;
+  }
+}
+```
+
+Alternatively you can write your own wrapper functions that hook up type
+inference. You can do this with any library that consumes the `DocumentNode` or
+`TypedDocumentNode` types. Here is an example wrapper for Apollo Client's
+`useQuery`:
+
+```ts
+import { gql, QueryHookOptions, QueryResult, useQuery } from "@apollo/client";
+import { TypedQueryDocumentNode } from "graphql";
+
+function useTypedQuery<ResponseData, Variables>(
+  query: TypedQueryDocumentNode<ResponseData, Variables>,
+  options: QueryHookOptions<ResponseData, Variables>
+): QueryResult<ResponseData, Variables> {
+  return useQuery(query, options);
+}
+
+// example usage
+const { data } = useTypedQuery(query, { variables: { take: 100 } });
+//      ^                                          ^
+//      inferred type is `MyQuery`                 |
+//                                                 |
+//                                        inferred type is `MyQueryVariables`
 ```
 
 ## Automated releases

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "ts-jest": "^26.4.3",
     "typescript": "^4.0.5"
   },
+  "peerDependencies": {
+    "graphql": ">=15.4.0",
+    "ts-graphql-plugin": ">=2.1.0"
+  },
   "engines": {
     "node": ">=12.9.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,15 +54,9 @@ function addNameToGqlTag(
 
   const name = document.operationName;
   const pathname = `./__generated__/${dasherize(name)}`;
-  const sanitizedPathname = JSON.stringify(pathname);
+  const documentTypeName = `${name}Document`;
 
-  const typedDocumentNodePackageName = "@graphql-typed-document-node/core";
-  const type = `import(${JSON.stringify(
-    typedDocumentNodePackageName
-  )}).TypedDocumentNode<
-  import(${sanitizedPathname}).${name},
-  import(${sanitizedPathname}).${name}Variables
->`;
+  const type = `import(${JSON.stringify(pathname)}).${documentTypeName}`;
 
   // Add a type assertion if there isn't one.
   if (node.parent?.type !== "TSAsExpression") {
@@ -82,40 +76,12 @@ function addNameToGqlTag(
       type: "TSImportType",
       parameter: {
         literal: {
-          value: typedDocumentNodePackageName,
+          value: pathname,
         },
       },
       qualifier: {
         type: "Identifier",
-        name: "TypedDocumentNode",
-      },
-      typeParameters: {
-        params: [
-          {
-            type: "TSImportType",
-            parameter: {
-              literal: {
-                value: pathname,
-              },
-            },
-            qualifier: {
-              type: "Identifier",
-              name: name,
-            },
-          },
-          {
-            type: "TSImportType",
-            parameter: {
-              literal: {
-                value: pathname,
-              },
-            },
-            qualifier: {
-              type: "Identifier",
-              name: `${name}Variables`,
-            },
-          },
-        ],
+        name: documentTypeName,
       },
     })
   ) {

--- a/test/__fixtures__/basic-fixed.ts
+++ b/test/__fixtures__/basic-fixed.ts
@@ -4,7 +4,4 @@ gql`
   query Thing {
     something
   }
-` as import("@graphql-typed-document-node/core").TypedDocumentNode<
-  import("./__generated__/thing").Thing,
-  import("./__generated__/thing").ThingVariables
->;
+` as import("./__generated__/thing").ThingDocument;

--- a/test/__fixtures__/invalid-type-assertion.ts
+++ b/test/__fixtures__/invalid-type-assertion.ts
@@ -4,25 +4,16 @@ gql`
   query Thing {
     something
   }
-` as SomeType<
-  import("./__generated__/thing").Thing,
-  import("./__generated__/thing").ThingVariables
->;
+` as SomeType;
 
 gql`
   query Thing {
     something
   }
-` as import("@graphql-typed-document-node/core").TypedDocumentNode<
-  import("./__generated__/thing").WrongThing,
-  import("./__generated__/thing").ThingVariables
->;
+` as import("./__generated__/thing").WrongThing;
 
 gql`
   query Thing {
     something
   }
-` as import("@graphql-typed-document-node/core").TypedDocumentNode<
-  import("./__generated__/thing").Thing,
-  import("./__generated__/wrong-thing").ThingVariables
->;
+` as import("./__generated__/wrong-thing").ThingDocument;

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -8,10 +8,7 @@ gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->;
+\` as import(\\"./__generated__/thing\\").ThingDocument;
 ",
   "lintMessages": Array [
     Object {
@@ -23,10 +20,7 @@ gql\`
           68,
           68,
         ],
-        "text": " as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->",
+        "text": " as import(\\"./__generated__/thing\\").ThingDocument",
       },
       "line": 3,
       "message": "You must cast gql tags with the generated type",
@@ -63,10 +57,7 @@ gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->;
+\` as import(\\"./__generated__/thing\\").ThingDocument;
 ",
 }
 `;
@@ -87,10 +78,7 @@ gql\`
   query GetThing {
     ...Fields
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/get-thing\\").GetThing,
-  import(\\"./__generated__/get-thing\\").GetThingVariables
->
+\` as import(\\"./__generated__/get-thing\\").GetThingDocument
 ",
   "lintMessages": Array [
     Object {
@@ -102,10 +90,7 @@ gql\`
           160,
           160,
         ],
-        "text": " as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/get-thing\\").GetThing,
-  import(\\"./__generated__/get-thing\\").GetThingVariables
->",
+        "text": " as import(\\"./__generated__/get-thing\\").GetThingDocument",
       },
       "line": 10,
       "message": "You must cast gql tags with the generated type",
@@ -149,43 +134,31 @@ gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->;
+\` as import(\\"./__generated__/thing\\").ThingDocument;
 
 gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->;
+\` as import(\\"./__generated__/thing\\").ThingDocument;
 
 gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->;
+\` as import(\\"./__generated__/thing\\").ThingDocument;
 ",
   "lintMessages": Array [
     Object {
       "column": 6,
-      "endColumn": 2,
-      "endLine": 10,
+      "endColumn": 14,
+      "endLine": 7,
       "fix": Object {
         "range": Array [
           72,
-          173,
+          80,
         ],
-        "text": "import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->",
+        "text": "import(\\"./__generated__/thing\\").ThingDocument",
       },
       "line": 7,
       "message": "The type assertion on a gql tag is not in the expected format",
@@ -196,19 +169,16 @@ gql\`
     },
     Object {
       "column": 6,
-      "endColumn": 2,
-      "endLine": 19,
+      "endColumn": 48,
+      "endLine": 13,
       "fix": Object {
         "range": Array [
-          220,
-          379,
+          127,
+          169,
         ],
-        "text": "import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->",
+        "text": "import(\\"./__generated__/thing\\").ThingDocument",
       },
-      "line": 16,
+      "line": 13,
       "message": "The type assertion on a gql tag is not in the expected format",
       "messageId": "mustUseAsCorrectly",
       "nodeType": "TSImportType",
@@ -217,19 +187,16 @@ gql\`
     },
     Object {
       "column": 6,
-      "endColumn": 2,
-      "endLine": 28,
+      "endColumn": 57,
+      "endLine": 19,
       "fix": Object {
         "range": Array [
-          426,
-          586,
+          216,
+          267,
         ],
-        "text": "import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-  import(\\"./__generated__/thing\\").Thing,
-  import(\\"./__generated__/thing\\").ThingVariables
->",
+        "text": "import(\\"./__generated__/thing\\").ThingDocument",
       },
-      "line": 25,
+      "line": 19,
       "message": "The type assertion on a gql tag is not in the expected format",
       "messageId": "mustUseAsCorrectly",
       "nodeType": "TSImportType",
@@ -244,40 +211,22 @@ gql\`
   query Thing {
     something
   }
-\` as SomeType<
-     ~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
-  import(\\"./__generated__/thing\\").Thing,
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
-  import(\\"./__generated__/thing\\").ThingVariables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
->;
-~    [The type assertion on a gql tag is not in the expected format]
+\` as SomeType;
+     ~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
 
 gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
-  import(\\"./__generated__/thing\\").WrongThing,
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
-  import(\\"./__generated__/thing\\").ThingVariables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
->;
-~    [The type assertion on a gql tag is not in the expected format]
+\` as import(\\"./__generated__/thing\\").WrongThing;
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
 
 gql\`
   query Thing {
     something
   }
-\` as import(\\"@graphql-typed-document-node/core\\").TypedDocumentNode<
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
-  import(\\"./__generated__/thing\\").Thing,
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
-  import(\\"./__generated__/wrong-thing\\").ThingVariables
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
->;
-~    [The type assertion on a gql tag is not in the expected format]
+\` as import(\\"./__generated__/wrong-thing\\").ThingDocument;
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    [The type assertion on a gql tag is not in the expected format]
 ",
 }
 `;


### PR DESCRIPTION
Instead of specifying a `TypedDocumentNode` type inline in each type
assertion, with this change we import pre-generated
`TypedQueryDocumentNode` alias from files generated by
ts-graphql-plugin.

BREAKING CHANGE: From now on you must use graphql v15.4.0 or later, and
ts-graphql-plugin v2.1.0 or later.